### PR TITLE
Implement symbolic links

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -23,6 +23,7 @@ pub(crate) static TEST_ASAR: &[u8] = include_bytes!("../data/test.asar");
 pub enum Header {
 	File(File),
 	Directory { files: HashMap<String, Self> },
+	Link { link: String },
 }
 
 impl Header {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -204,6 +204,7 @@ fn recursive_add_to_header(mut path: VecDeque<String>, file: File, header: &mut 
 	let header_map = match header {
 		Header::File(_) => return,
 		Header::Directory { files } => files,
+		Header::Link { link: _ } => return,
 	};
 	match path.pop_front() {
 		Some(name) if path.is_empty() => {


### PR DESCRIPTION
This pull request aims to implement symbolic links. In an `.asar` file's header JSON, a link looks like this:

```json
"file" {
  "link": "path/to/actual/file.txt"
}
```

From the looks of the Node.js asar package, symbolic links are considered different from files (and obviously directories). [Symbolic links](https://en.wikipedia.org/wiki/Symbolic_link) should serialize as this type, and vice-versa for deserialization. I've started implementing this, but haven't finished. If anyone would like to finish it for me, please feel free, as I hardly know what I'm doing.

This pull request resolves #2.